### PR TITLE
Refactored RR AP Integration

### DIFF
--- a/Patches/SongCompletePatches.cs
+++ b/Patches/SongCompletePatches.cs
@@ -37,26 +37,14 @@ namespace RiftArchipelago.Patches
         private static StageFlowUiController.StageContextInfo _stageContextInfo;
 
         private static readonly AccessTools.FieldRef<RRStageController, bool> _isMicroRiftRef =
-            AccessTools.FieldRefAccess<RRStageController, bool>("_isMicroRift");
-        private static bool _isMicroRift = false;
-
-        private static readonly AccessTools.FieldRef<RRStageController, bool> _isTutorialRef =
-            AccessTools.FieldRefAccess<RRStageController, bool>("_isTutorial");
-        private static bool _isTutorial = false;
-
-        private static readonly AccessTools.FieldRef<RRStageController, bool> _isPracticeModeRef =
-            AccessTools.FieldRefAccess<RRStageController, bool>("_isPracticeMode");
-        private static bool _isPracticeMode = false;
-
+            AccessTools.FieldRefAccess<RRStageController, bool>("_isMicroRift");        
         private static readonly AccessTools.FieldRef<RRStageController, bool> _wereCheatsUsedRef =
             AccessTools.FieldRefAccess<RRStageController, bool>("_wereCheatsUsed");
+        private static bool _isMicroRift = false;
+        private static bool _isTutorial = false;
+        private static bool _isPracticeMode = false;
         private static bool _wereCheatsUsed = false;
-
-        private static readonly AccessTools.FieldRef<RRStageController, bool> _isCalibrationTestRef =
-            AccessTools.FieldRefAccess<RRStageController, bool>("_isCalibrationTest");
-
         private static bool _isRemixMode = false;
-
         private static bool _isDailyChallenge = false;
 
         // Runs at the end of the method that handles successfully beating a stage

--- a/Patches/SongCompletePatches.cs
+++ b/Patches/SongCompletePatches.cs
@@ -118,10 +118,10 @@ namespace RiftArchipelago.Patches
                 if (_isDailyChallenge) RiftAP._log.LogInfo("Daily Challenge Mode, Not sending checks");
                 if (_isTutorial) RiftAP._log.LogInfo("Tutorial Mode, Not sending checks");
                 if (_isPracticeMode) RiftAP._log.LogInfo("Practice Mode, Not sending checks");
-                if (_wereCheatsUsed) RiftAP._log.LogInfo("Cheats were used, Not sending checks");
+                if (_wereCheatsUsed) RiftAP._log.LogInfo("Cheats were used.");
 
                 // Break out if any illegal modes were detected
-                if (_isTutorial || _isPracticeMode || _isDailyChallenge || _wereCheatsUsed) {
+                if (_isTutorial || _isPracticeMode || _isDailyChallenge ) {
                     RiftAP._log.LogInfo("Tutorial, Practice, Cheats or Challenge mode detected: skipping AP Send");
                     RiftAP._log.LogInfo("-----");
                     return;

--- a/Patches/SongCompletePatches.cs
+++ b/Patches/SongCompletePatches.cs
@@ -1,4 +1,5 @@
 using HarmonyLib;
+
 using Shared;
 using System.Threading.Tasks;
 
@@ -7,95 +8,401 @@ using Archipelago.MultiClient.Net.Enums;
 using Archipelago.MultiClient.Net.Packets;
 using Shared.Leaderboard;
 using Shared.TrackSelection;
+using RhythmRift;
+using BossBattles;
+using System.Buffers.Text;
+using System.Collections.Generic;
+using Shared.SceneLoading.Payloads;
+using System.Reflection;
 
-namespace RiftArchipelago.Patches{
-    [HarmonyPatch(typeof(StageFlowUiController), "ShowResults")]
-    public static class APLocationSend {
+namespace RiftArchipelago.Patches
+{
+    [HarmonyPatch(typeof(RRStageController), "CompleteStageAfterAllEnemiesHaveDiedRoutine")]
+    public static class RRCompleteStage
+    {
+        //  fast access to private fields on RRStageController
+        private static LetterGradeDefinitions _letterGradeDefinitions = null;
+        private static readonly AccessTools.FieldRef<RRStageController, StageInputRecord> _stageInputRecordRef =
+            AccessTools.FieldRefAccess<RRStageController, StageInputRecord>("_stageInputRecord");
+        private static StageInputRecord _stageInputRecord = null;
+
+        private static readonly AccessTools.FieldRef<RRStageController, StageScenePayload> _stageScenePayloadRef =
+            AccessTools.FieldRefAccess<RRStageController, StageScenePayload>("_stageScenePayload");
+        private static StageScenePayload _stageScenePayload = null;
+
+        private static readonly AccessTools.FieldRef<RRStageController, StageFlowUiController> _stageFlowUiControllerRef =
+            AccessTools.FieldRefAccess<RRStageController, StageFlowUiController>("_stageFlowUiController");
+        private static StageFlowUiController _stageFlowUiController = null;
+
+        private static StageFlowUiController.StageContextInfo _stageContextInfo;
+
+        private static readonly AccessTools.FieldRef<RRStageController, bool> _isMicroRiftRef =
+            AccessTools.FieldRefAccess<RRStageController, bool>("_isMicroRift");
+        private static bool _isMicroRift = false;
+
+        private static readonly AccessTools.FieldRef<RRStageController, bool> _isTutorialRef =
+            AccessTools.FieldRefAccess<RRStageController, bool>("_isTutorial");
+        private static bool _isTutorial = false;
+
+        private static readonly AccessTools.FieldRef<RRStageController, bool> _isPracticeModeRef =
+            AccessTools.FieldRefAccess<RRStageController, bool>("_isPracticeMode");
+        private static bool _isPracticeMode = false;
+
+        private static readonly AccessTools.FieldRef<RRStageController, bool> _wereCheatsUsedRef =
+            AccessTools.FieldRefAccess<RRStageController, bool>("_wereCheatsUsed");
+        private static bool _wereCheatsUsed = false;
+
+        private static readonly AccessTools.FieldRef<RRStageController, bool> _isCalibrationTestRef =
+            AccessTools.FieldRefAccess<RRStageController, bool>("_isCalibrationTest");
+
+        private static bool _isRemixMode = false;
+
+        private static bool _isDailyChallenge = false;
+
+        // Runs at the end of the method that handles successfully beating a stage
         [HarmonyPostfix]
-        public static void PostFix(StageFlowUiController __instance, ref StageFlowUiController.StageContextInfo ____stageContextInfo, StageInputRecord stageInputRecord, 
-                                   float trackProgressPercentage, bool didNotFinish, bool cheatsDetected, bool isRemixMode, string bossName) {
+        public static void PostFix(RRStageController __instance)
+        {
+            try
+            {
+                if (__instance == null)
+                {
+                    RiftAP._log.LogError("RRStageEnd PostFix: __instance == null");
+                    return;
+                }
+
+                // Get private fields
+                try
+                {
+                    GetPrivateFields(__instance);
+                }
+                catch (System.Exception ex)
+                {
+                    RiftAP._log.LogError($"Error getting private fields in RRStageEnd PostFix: {ex}");
+                    return;
+                }
+
+                // Double check to ensure no null values
+                if (_letterGradeDefinitions == null || _stageInputRecord == null || _stageScenePayload == null)
+                {
+                    RiftAP._log.LogWarning("RRStageEnd PostFix: One or more private fields are null");
+                    return;
+                }
+
+                // I don't know what this even does but I think it was already here so I will leave it
+                if (_stageInputRecord.BaseStageScore == 0)
+                {
+                    RiftAP._log.LogWarning("RRStageEnd PostFix: BaseStageScore == 0");
+                    return;
+                }
+
+                // Copy letter grade calculation from the original files
+                float percentage = (float)_stageInputRecord.TotalScore / _stageInputRecord.BaseStageScore * 100f;
+                string letter = _letterGradeDefinitions.GetLetterGradeForPercentage(percentage);
+                if (_isMicroRift && letter != LetterGradeDefinitions.LetterGrades.SS.ToString())
+                {
+                    List<float> thresholds = _letterGradeDefinitions.GetLetterGradePercentageThresholdsInOrder();
+                    if (thresholds != null && thresholds.Count > 0)
+                    {
+                        float num = thresholds[thresholds.Count - 1];
+                        int extraScore = (int)((float)_stageInputRecord.BaseStageScore * num) + 1 - _stageInputRecord.TotalScore;
+                        _stageInputRecord.AddMicroRiftCompletionBonus(extraScore);
+                        letter = LetterGradeDefinitions.LetterGrades.SS.ToString();
+                    }
+                }
+
+                // Get important properties
+                string levelId = _stageScenePayload.GetLevelId();
+                string stageDisplayName = _stageContextInfo.StageDisplayName;
+                bool wasFullCombo = _stageInputRecord.TotalMisses == 0;
+
+                // Print out for debugging purposes
+                RiftAP._log.LogInfo("-----");
+                RiftAP._log.LogInfo("Song Complete!");
+                RiftAP._log.LogInfo($"Stage Display Name: {stageDisplayName}");
+                RiftAP._log.LogInfo($"Level ID: {levelId}");
+                RiftAP._log.LogInfo($"Difficulty: {_stageScenePayload.GetLevelDifficulty()}");
+                RiftAP._log.LogInfo($"Final Letter Grade: {letter}");
+                if (wasFullCombo) RiftAP._log.LogInfo("Full Combo Achieved!");
+                if (_isDailyChallenge) RiftAP._log.LogInfo("Daily Challenge Mode, Not sending checks");
+                if (_isTutorial) RiftAP._log.LogInfo("Tutorial Mode, Not sending checks");
+                if (_isPracticeMode) RiftAP._log.LogInfo("Practice Mode, Not sending checks");
+                if (_wereCheatsUsed) RiftAP._log.LogInfo("Cheats were used, Not sending checks");
+
+                // Break out if any illegal modes were detected
+                if (_isTutorial || _isPracticeMode || _isDailyChallenge || _wereCheatsUsed)
+                {
+                    RiftAP._log.LogInfo("Tutorial, Practice, Cheats or Challenge mode detected: skipping AP Send");
+                    RiftAP._log.LogInfo("-----");
+                    return;
+                }
+
+                if (!ArchipelagoClient.isAuthenticated)
+                {
+                    RiftAP._log.LogInfo("Not connected to Archipelago: skipping AP Send");
+                    RiftAP._log.LogInfo("-----");
+                    return;
+                }
+
+                try
+                {
+                    AP_RRLocationSend(stageDisplayName, levelId, _stageScenePayload.GetLevelDifficulty(), letter, wasFullCombo, _isRemixMode, false);
+                }
+                catch (System.Exception ex)
+                {
+                    RiftAP._log.LogError($"Error in APLocationSend: {ex}");
+                }
+                RiftAP._log.LogInfo("-----");
+
+            }
+            catch (System.Exception ex)
+            {
+                RiftAP._log.LogError($"Error in RRStageEnd PostFix: {ex}");
+            }
+        }
+
+        public static void AP_RRLocationSend(string stageDisplayName, string levelId, Difficulty difficulty, string letterGrade, bool isFullCombo, bool isRemixMode, bool isCustom)
+        {
+
+            if (isCustom) return; // Custom songs not implemented yet
+
+            long locId = -1;
+
+            if (!ArchipelagoClient.slotData.remix || !isRemixMode)
+            {
+                if (stageDisplayName == ArchipelagoClient.slotData.goalSong)
+                {
+                    ArchipelagoClient.GoalGame();
+                }
+
+                locId = ArchipelagoClient.session.Locations.GetLocationIdFromName("Rift of the Necrodancer", stageDisplayName + "-0");
+            }
+            else
+            {
+                if (stageDisplayName + " (Remix)" == ArchipelagoClient.slotData.goalSong)
+                {
+                    ArchipelagoClient.GoalGame();
+                }
+
+                locId = ArchipelagoClient.session.Locations.GetLocationIdFromName("Rift of the Necrodancer", stageDisplayName + " (Remix)-0");
+            }
+
+
+            RiftAP._log.LogInfo($"Sending {stageDisplayName} {locId}");
+
+            if (locId != -1)
+            {
+                ArchipelagoClient.session.Locations.CompleteLocationChecksAsync([locId, locId + 1]);
+            }
+        }
+        public static void GetPrivateFields(RRStageController __instance)
+        {
+            // BeatmapPlayer: try property first, then field
+            object beatmapPlayer = null;
+            try { beatmapPlayer = Traverse.Create(__instance).Property("BeatmapPlayer").GetValue(); } catch { }
+            if (beatmapPlayer == null)
+            {
+                try { beatmapPlayer = Traverse.Create(__instance).Field("BeatmapPlayer").GetValue(); } catch { }
+            }
+            if (beatmapPlayer == null)
+            {
+                RiftAP._log.LogWarning("RRStageEnd PostFix: BeatmapPlayer == null");
+                return;
+            }
+
+            // LetterGradeDefinitions: property then field
+            try { _letterGradeDefinitions = Traverse.Create(beatmapPlayer).Property("LetterGradeDefinitions").GetValue<LetterGradeDefinitions>(); } catch { }
+            if (_letterGradeDefinitions == null)
+            {
+                try { _letterGradeDefinitions = Traverse.Create(beatmapPlayer).Field("LetterGradeDefinitions").GetValue<LetterGradeDefinitions>(); } catch { }
+            }
+            if (_letterGradeDefinitions == null)
+            {
+                RiftAP._log.LogWarning("RRStageEnd PostFix: LetterGradeDefinitions == null");
+                return;
+            }
+
+            // stageInputRecord: preferred via FieldRef, fallback to Traverse
+            try { _stageInputRecord = _stageInputRecordRef(__instance); } catch { }
+            if (_stageInputRecord == null)
+            {
+                try { _stageInputRecord = Traverse.Create(__instance).Field("_stageInputRecord").GetValue<StageInputRecord>(); } catch { }
+            }
+            if (_stageInputRecord == null)
+            {
+                RiftAP._log.LogWarning("RRStageEnd PostFix: _stageInputRecord == null");
+                return;
+            }
+
+            // stageFlowUiController: preferred via FieldRef, fallback to Traverse
+            try { _stageFlowUiController = _stageFlowUiControllerRef(__instance); } catch { }
+            if (_stageFlowUiController == null)
+            {
+                try { _stageFlowUiController = Traverse.Create(__instance).Field("_stageFlowUiController").GetValue<StageFlowUiController>(); } catch { }
+            }
+            if (_stageFlowUiController == null)
+            {
+                RiftAP._log.LogWarning("RRStageEnd PostFix: _stageFlowUiController == null");
+                return;
+            }
+
+            // Get DisplayName
+            try
+            {
+                _stageContextInfo = (StageFlowUiController.StageContextInfo)typeof(StageFlowUiController).InvokeMember("_stageContextInfo", BindingFlags.GetField
+                        | BindingFlags.Instance | BindingFlags.NonPublic, null, _stageFlowUiController, null);
+            }
+            catch (System.Exception e)
+            {
+                RiftAP._log.LogWarning(e.StackTrace + e.Message);
+                return;
+            }
+
+            // stageScenePayload: preferred via FieldRef, fallback to Traverse
+            try { _stageScenePayload = _stageScenePayloadRef(__instance); } catch { }
+            if (_stageScenePayload == null)
+            {
+                try { _stageScenePayload = Traverse.Create(__instance).Field("_stageScenePayload").GetValue<StageScenePayload>(); } catch { }
+            }
+            if (_stageInputRecord == null)
+            {
+                RiftAP._log.LogWarning("RRStageEnd PostFix: _stageInputRecord == null");
+                return;
+            }
+
+            try { _isMicroRift = _isMicroRiftRef(__instance); }
+            catch
+            {
+                try { _isMicroRift = Traverse.Create(__instance).Field("_isMicroRift").GetValue<bool>(); } catch { }
+            }
+
+            try { _wereCheatsUsed = _wereCheatsUsedRef(__instance); }
+            catch
+            {
+                try { _wereCheatsUsed = Traverse.Create(__instance).Field("_wereCheatsUsed").GetValue<bool>(); } catch { }
+            }
+
+            try { _isTutorial = _stageScenePayload.GetIsTutorial(); }
+            catch { _isTutorial = false; }
+
+            try { _isPracticeMode = _stageScenePayload.IsPracticeMode; }
+            catch { _isPracticeMode = false; }
+
+            try { _isRemixMode = _stageScenePayload.ShouldProcGen; }
+            catch { _isRemixMode = false; }
+
+            try { _isDailyChallenge = _stageScenePayload.IsDailyChallenge; }
+            catch { _isDailyChallenge = false; }
+        }
+    }
+
+    [HarmonyPatch(typeof(StageFlowUiController), "ShowResults")]
+    public static class StageResultInformation
+    {
+        public static StageResultSnapshot _lastSnapshot;
+        public struct StageResultSnapshot
+        {
+            public bool didNotFinishSS;
+            public bool cheatsDetectedSS;
+            public bool isRemixModeSS;
+            public bool wasFullComboSS;
+        }
+
+        [HarmonyPostfix]
+        public static void PreFix(StageFlowUiController __instance, ref StageFlowUiController.StageContextInfo ____stageContextInfo,
+                                    bool didNotFinish, bool cheatsDetected, bool isRemixMode, bool wasFullCombo)
+        {
+            RiftAP._log.LogInfo($"Setting last snapshot: didNotFinish={didNotFinish}, cheatsDetected={cheatsDetected}, isRemixMode={isRemixMode}, wasFullCombo={wasFullCombo}");
+            _lastSnapshot = new StageResultSnapshot()
+                {
+                    didNotFinishSS = didNotFinish,
+                    cheatsDetectedSS = cheatsDetected,
+                    isRemixModeSS = isRemixMode,
+                    wasFullComboSS = wasFullCombo
+                };
+        }
+    }
+
+    [HarmonyPatch(typeof(StageFlowUiController), "ShowResults")]
+    public static class APLocationSend
+    {
+        [HarmonyPostfix]
+        public static void PostFix(StageFlowUiController __instance, ref StageFlowUiController.StageContextInfo ____stageContextInfo, StageInputRecord stageInputRecord,
+                                   float trackProgressPercentage, bool didNotFinish, bool cheatsDetected, bool isRemixMode, string bossName)
+        {
             if (!ArchipelagoClient.isAuthenticated) return;
-            if(____stageContextInfo.IsDailyChallenge && ____stageContextInfo.IsChallenge) return;
+            if (____stageContextInfo.IsDailyChallenge && ____stageContextInfo.IsChallenge) return;
 
-            RiftAP._log.LogInfo($"Song Progress: {trackProgressPercentage}");
-            
-            if(trackProgressPercentage > 0 || ____stageContextInfo.LetterGradeDefinitions.IsBossBattle) {
-                RiftAP._log.LogInfo("Song Complete, sending checks!");
-                long locId = -1;
+            if (trackProgressPercentage <= 0 && !____stageContextInfo.LetterGradeDefinitions.IsBossBattle) return;
 
-                if(____stageContextInfo.IsCustomTrack) { // Custom Track Handling
-                    
+            long locId = -1;
+
+            if (____stageContextInfo.LetterGradeDefinitions.IsBossBattle)
+            { // Boss Battle Handling
+                RiftAP._log.LogInfo("Boss Battle Cleared");
+                if (ArchipelagoClient.slotData.bbMode == 1)
+                {
+                    if (____stageContextInfo.StageDisplayName == ArchipelagoClient.slotData.goalSong)
+                    {
+                        ArchipelagoClient.GoalGame();
+                    }
+
+                    locId = ArchipelagoClient.session.Locations.GetLocationIdFromName("Rift of the Necrodancer", ____stageContextInfo.StageDisplayName + "-0");
                 }
-
-                else if(____stageContextInfo.LetterGradeDefinitions.IsBossBattle) { // Boss Battle Handling
-                    RiftAP._log.LogInfo("Boss Battle Cleared");
-                    if(ArchipelagoClient.slotData.bbMode == 1) { 
-                        if(____stageContextInfo.StageDisplayName == ArchipelagoClient.slotData.goalSong) {
-                            ArchipelagoClient.GoalGame();
-                        }
-
-                        locId = ArchipelagoClient.session.Locations.GetLocationIdFromName("Rift of the Necrodancer", ____stageContextInfo.StageDisplayName + "-0");
+                else if (ArchipelagoClient.slotData.bbMode == 2)
+                {
+                    if ($"{____stageContextInfo.StageDisplayName} ({____stageContextInfo.StageDifficulty})" == ArchipelagoClient.slotData.goalSong)
+                    {
+                        ArchipelagoClient.GoalGame();
                     }
-                    else if(ArchipelagoClient.slotData.bbMode == 2) {
-                        if($"{____stageContextInfo.StageDisplayName} ({____stageContextInfo.StageDifficulty})" == ArchipelagoClient.slotData.goalSong) {
-                            ArchipelagoClient.GoalGame();
-                        }
 
-                        locId = ArchipelagoClient.session.Locations.GetLocationIdFromName("Rift of the Necrodancer", $"{____stageContextInfo.StageDisplayName} ({____stageContextInfo.StageDifficulty})-0");
-                    }
+                    locId = ArchipelagoClient.session.Locations.GetLocationIdFromName("Rift of the Necrodancer", $"{____stageContextInfo.StageDisplayName} ({____stageContextInfo.StageDifficulty})-0");
                 }
+            }
 
-                else if(____stageContextInfo.LetterGradeDefinitions.name == "LetterGradeDefinitionsMG") { // Minigame Handling
-                    RiftAP._log.LogInfo("Minigame Cleared");
-                    if(ArchipelagoClient.slotData.mgMode == 1) { 
-                        if(____stageContextInfo.StageDisplayName == ArchipelagoClient.slotData.goalSong) {
-                            ArchipelagoClient.GoalGame();
-                        }
-
-                        locId = ArchipelagoClient.session.Locations.GetLocationIdFromName("Rift of the Necrodancer", ____stageContextInfo.StageDisplayName + "-0");
+            else if (____stageContextInfo.LetterGradeDefinitions.name == "LetterGradeDefinitionsMG")
+            { // Minigame Handling
+                RiftAP._log.LogInfo("Minigame Cleared");
+                if (ArchipelagoClient.slotData.mgMode == 1)
+                {
+                    if (____stageContextInfo.StageDisplayName == ArchipelagoClient.slotData.goalSong)
+                    {
+                        ArchipelagoClient.GoalGame();
                     }
-                    else if(ArchipelagoClient.slotData.mgMode == 2) {
-                        if($"{____stageContextInfo.StageDisplayName} ({____stageContextInfo.StageDifficulty})" == ArchipelagoClient.slotData.goalSong) {
-                            ArchipelagoClient.GoalGame();
-                        }
 
-                        locId = ArchipelagoClient.session.Locations.GetLocationIdFromName("Rift of the Necrodancer", $"{____stageContextInfo.StageDisplayName} ({____stageContextInfo.StageDifficulty})-0");
-                    }
+                    locId = ArchipelagoClient.session.Locations.GetLocationIdFromName("Rift of the Necrodancer", ____stageContextInfo.StageDisplayName + "-0");
                 }
-
-                else { // Vanilla song
-                    RiftAP._log.LogInfo("Remix Mode: " + isRemixMode);
-                    if(!ArchipelagoClient.slotData.remix || !isRemixMode) {
-                        if(____stageContextInfo.StageDisplayName == ArchipelagoClient.slotData.goalSong) {
-                            ArchipelagoClient.GoalGame();
-                        }
-
-                        locId = ArchipelagoClient.session.Locations.GetLocationIdFromName("Rift of the Necrodancer", ____stageContextInfo.StageDisplayName + "-0");
+                else if (ArchipelagoClient.slotData.mgMode == 2)
+                {
+                    if ($"{____stageContextInfo.StageDisplayName} ({____stageContextInfo.StageDifficulty})" == ArchipelagoClient.slotData.goalSong)
+                    {
+                        ArchipelagoClient.GoalGame();
                     }
-                    else {
-                        if(____stageContextInfo.StageDisplayName + " (Remix)" == ArchipelagoClient.slotData.goalSong) {
-                            ArchipelagoClient.GoalGame();
-                        }
 
-                        locId = ArchipelagoClient.session.Locations.GetLocationIdFromName("Rift of the Necrodancer", ____stageContextInfo.StageDisplayName + " (Remix)-0");
-                    }
+                    locId = ArchipelagoClient.session.Locations.GetLocationIdFromName("Rift of the Necrodancer", $"{____stageContextInfo.StageDisplayName} ({____stageContextInfo.StageDifficulty})-0");
                 }
+            }
 
-                RiftAP._log.LogInfo($"Sending {____stageContextInfo.StageDisplayName} {locId}");
+            else { return; }
 
-                if(locId != -1) {
-                    ArchipelagoClient.session.Locations.CompleteLocationChecksAsync([locId, locId + 1]);
-                }
+            RiftAP._log.LogInfo($"Sending {____stageContextInfo.StageDisplayName} {locId}");
+
+            if (locId != -1)
+            {
+                ArchipelagoClient.session.Locations.CompleteLocationChecksAsync([locId, locId + 1]);
             }
         }
     }
 
     [HarmonyPatch(typeof(LeaderboardDataAccessor), "UploadScoreToLeaderboard")]
-    public static class LeaderboardUploadOverride {
-        private static bool Prefix(out Task<bool> __result) {
+    public static class LeaderboardUploadOverride
+    {
+        // Prevent uploading scores to the leaderboard if connected to Archipelago
+        private static bool Prefix(out Task<bool> __result)
+        {
             RiftAP._log.LogInfo($"Uploading Score: {!ArchipelagoClient.isAuthenticated}");
             __result = Task.FromResult(false);
             return !ArchipelagoClient.isAuthenticated;
         }
-}
+    }
 }

--- a/Patches/SongCompletePatches.cs
+++ b/Patches/SongCompletePatches.cs
@@ -96,17 +96,18 @@ namespace RiftArchipelago.Patches
 
                 string levelId = _stageScenePayload.GetLevelId();
                 string stageDisplayName = _stageContextInfo.StageDisplayName;
-                bool wasFullCombo = _stageInputRecord.TotalMisses == 0;
+                bool wasFullCombo = _stageInputRecord.TotalMisses == 0 && _stageInputRecord.TotalErrants == 0;
 
                 try
                 {
-                    RiftAP._log.LogInfo("-----");
                     if (VerifyCompletionRequirements(stageDisplayName, levelId, _stageScenePayload.GetLevelDifficulty(), SlotData.MapObjectToGrade(letter), wasFullCombo, _isRemixMode, false, _wereCheatsUsed))
                     {
                         RiftAP._log.LogInfo("Archipelago location verification validated");
                         AP_RRLocationSend(stageDisplayName, levelId, _stageScenePayload.GetLevelDifficulty(), _isRemixMode);
                     }
-                    RiftAP._log.LogInfo("-----");
+                    else {
+                        RiftAP._log.LogInfo("Archipelago location verification failed. Not sending check.");
+                    }
                 }
                 catch (System.Exception ex)
                 {
@@ -131,21 +132,22 @@ namespace RiftArchipelago.Patches
             // Invalid if any illegal modes were detected
             if (_isTutorial || _isPracticeMode || _isDailyChallenge)
             {
-                RiftAP._log.LogInfo("Tutorial, Practice, or Challenge mode detected: skipping AP Send");
+                RiftAP._log.LogInfo("Tutorial, Practice, or Challenge mode detected.");
                 return false;
             }
 
             // Print out for debugging purposes
-            RiftAP._log.LogInfo("Song Complete!");
-            RiftAP._log.LogInfo($"Stage Display Name: {stageDisplayName}");
-            RiftAP._log.LogInfo($"Level ID: {levelId}");
-            RiftAP._log.LogInfo($"Difficulty: {_stageScenePayload.GetLevelDifficulty()}");
-            RiftAP._log.LogInfo($"Final Letter Grade: {letterGrade}");
-            if (isFullCombo) RiftAP._log.LogInfo("Full Combo Achieved!");
+            RiftAP._log.LogInfo($"Song Completed! Stage: {stageDisplayName} | Level ID: {levelId} | Difficulty: {_stageScenePayload.GetLevelDifficulty()}");
+
+            // Full combo check
+            if (ArchipelagoClient.slotData.fullComboNeeded && !isFullCombo)
+            {
+                RiftAP._log.LogInfo("Full Combo required but not achieved");
+                return false;
+            }
 
             // Grade threshold check
             SlotData.Grade gradeNeeded = ArchipelagoClient.slotData.gradeNeeded;
-            RiftAP._log.LogInfo($"Grade Needed: {gradeNeeded}");
             if (letterGrade < gradeNeeded)
             {
                 RiftAP._log.LogInfo($"Grade {letterGrade} does not meet the requirement of {gradeNeeded}");

--- a/SlotData.cs
+++ b/SlotData.cs
@@ -11,6 +11,7 @@ namespace RiftArchipelago {
         public bool remix {get; private set;}
         public int mgMode {get; private set;}
         public int bbMode {get; private set;}
+        public bool fullComboNeeded {get; private set;}
 
         public SlotData(Dictionary<string, object> slotData) {
             if(slotData.TryGetValue("diamondWinCount", out var diamond_goal)) {
@@ -33,6 +34,9 @@ namespace RiftArchipelago {
             }
             if (slotData.TryGetValue("gradeNeeded", out var grade_needed)) {
                 gradeNeeded = MapObjectToGrade(grade_needed);
+            }
+            if (slotData.TryGetValue("fullComboNeeded", out var fc_needed)) {
+                fullComboNeeded = Convert.ToBoolean(fc_needed);
             }
         }
 

--- a/SlotData.cs
+++ b/SlotData.cs
@@ -32,10 +32,38 @@ namespace RiftArchipelago {
             if(slotData.TryGetValue("bossMode", out var boss_mode)) {
                 bbMode = ParseInt(boss_mode);
             }
+            if (slotData.TryGetValue("gradeNeeded", out var grade_needed)) {
+                gradeNeeded = MapGradeValue(grade_needed);
+            }
         }
 
         private int ParseInt(object i) {
             return int.TryParse(i.ToString(), out var result) ? result : -1;
+        }
+
+        private string MapGradeValue(object g) {
+            if (g == null) return null;
+            var s = g.ToString().Trim().ToUpper();
+
+            // If it gets sent as an enum value
+            if (int.TryParse(s, out var n)) {
+                return n switch {
+                    0 => "Any",
+                    1 => "D",
+                    2 => "C",
+                    3 => "B",
+                    4 => "A",
+                    5 => "S",
+                    _ => null,
+                };
+            }
+
+            // If it is sent as a string
+            var up = s.ToUpperInvariant();
+            if (up == "S_plus") return "SS";
+            if (up == "ANY" || up == "NONE") return "Any";
+
+            return up;
         }
     }
 }

--- a/SlotData.cs
+++ b/SlotData.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Collections.Generic;
-using BepInEx.Logging;
 
 namespace RiftArchipelago {
 
@@ -8,7 +7,7 @@ namespace RiftArchipelago {
         public int diamondGoal {get; private set;}
         public string goalSong {get; private set;}
         public bool deathLink {get; private set;}
-        public string gradeNeeded {get; private set;}
+        public Grade gradeNeeded {get; private set;}
         public bool remix {get; private set;}
         public int mgMode {get; private set;}
         public int bbMode {get; private set;}
@@ -33,7 +32,7 @@ namespace RiftArchipelago {
                 bbMode = ParseInt(boss_mode);
             }
             if (slotData.TryGetValue("gradeNeeded", out var grade_needed)) {
-                gradeNeeded = MapGradeValue(grade_needed);
+                gradeNeeded = MapObjectToGrade(grade_needed);
             }
         }
 
@@ -41,29 +40,41 @@ namespace RiftArchipelago {
             return int.TryParse(i.ToString(), out var result) ? result : -1;
         }
 
-        private string MapGradeValue(object g) {
-            if (g == null) return null;
+        public static Grade MapObjectToGrade(object g) {
+            if (g == null) return Grade.Any;
             var s = g.ToString().Trim().ToUpper();
 
             // If it gets sent as an enum value
             if (int.TryParse(s, out var n)) {
                 return n switch {
-                    0 => "Any",
-                    1 => "D",
-                    2 => "C",
-                    3 => "B",
-                    4 => "A",
-                    5 => "S",
-                    _ => null,
+                    0 => Grade.Any,
+                    1 => Grade.C,
+                    2 => Grade.B,
+                    3 => Grade.A,
+                    4 => Grade.S,
+                    5 => Grade.SS,
+                    _ => Grade.Any,
                 };
             }
 
             // If it is sent as a string
             var up = s.ToUpperInvariant();
-            if (up == "S_plus") return "SS";
-            if (up == "ANY" || up == "NONE") return "Any";
+            if (up == "S_PLUS") return Grade.SS;
+            else if (up == "SS") return Grade.SS;
+            else if (up == "S") return Grade.S;
+            else if (up == "A") return Grade.A;
+            else if (up == "B") return Grade.B;
+            else if (up == "C") return Grade.C;
+            else return Grade.Any;
+        }
 
-            return up;
+        public enum Grade {
+            Any = 0,
+            C = 1,
+            B = 2,
+            A = 3,
+            S = 4,
+            SS = 5
         }
     }
 }


### PR DESCRIPTION
- Moved RR logic into a separate class using a different Harmony Postfix method.
- Left Boss Battle and Mini Game logic untouched.
- Updated logic to send more information to the Archipelago Client (stageDisplayName, levelId, difficulty, letterGrade, isFullCombo, and isRemixMode). These will not be read by the apworld yet, but will be necessary later.
- Uses private fields inside the RhythmRift.RRStageController classes by some weird Harmony helpers and syntax (it works, so I just left it)