### PR TITLE
AP UI revamp

### DIFF
--- a/ArchipelagoUI.cs
+++ b/ArchipelagoUI.cs
@@ -10,7 +10,6 @@ namespace RiftArchipelago{
         private string hostInputCache = "";
         private string slotInputCache = "";
         private string passwordInputCache = "";
-        private bool showPassword = false;
         private bool failedLastAuthenticationAttempt = false;
         private static bool isMinimized;
 

--- a/ArchipelagoUI.cs
+++ b/ArchipelagoUI.cs
@@ -2,43 +2,106 @@ using UnityEngine;
 
 namespace RiftArchipelago{
     public class ArchipelagoUI : MonoBehaviour {
+        // Minimize state persisted between sessions
+        private const string MinimizedPrefKey = "RiftArchipelago_UI_Minimized";
+        private static bool isMinimized;
+
+        private const int PanelX = 8;
+        private const int PanelY = 8;
+        private const int PanelWidth = 320;
+        private const int PanelPadding = 8;
+
+        // New layout constants
+        private const int LeftPadding = 12;
+        private const int RightPadding = 12;
+        private const int LabelWidth = 120;
+        private const int FieldGap = 8;
+        private const int LineHeight = 20;
+
+        private void Awake() {
+            isMinimized = PlayerPrefs.GetInt(MinimizedPrefKey, 0) == 1;
+        }
+
+        private static void SetMinimized(bool value) {
+            isMinimized = value;
+            PlayerPrefs.SetInt(MinimizedPrefKey, value ? 1 : 0);
+            PlayerPrefs.Save();
+        }
+
         private void OnGUI() {
             if (Event.current.type == EventType.KeyDown && Event.current.keyCode == KeyCode.LeftAlt) {
                 Cursor.visible = !Cursor.visible;
             }
 
-            // Yoinked directly from Corn Kidz randomizer, which was yoinked directly from Subnautica randomizer
-            // https://github.com/Berserker66/ArchipelagoSubnauticaModSrc/blob/master/mod/Archipelago.cs
+            // If minimized, show a small maximize button in the top-left corner and bail out
+            if (isMinimized) {
+                if (GUI.Button(new Rect(PanelX, PanelY, 32, 22), "AP")) {
+                    SetMinimized(false);
+                }
+                return;
+            }
+
+            // Compute panel height based on visible content
+            bool inMenu = ArchipelagoClient.state == APState.Menu;
+            bool hasSession = ArchipelagoClient.session != null;
+            bool isAuthed = ArchipelagoClient.isAuthenticated;
+            bool showLogin = (!hasSession || !isAuthed) && inMenu;
+            bool showConnectedMenu = inMenu && hasSession;
+
+            int panelHeight = 60; // base for status only
+            if (showLogin) panelHeight = 140;
+            else if (showConnectedMenu) panelHeight = 110;
+
+            // Precompute column positions to avoid overflow
+            int labelX = LeftPadding;
+            int fieldX = LeftPadding + LabelWidth + FieldGap;
+            int fieldWidth = PanelWidth - fieldX - RightPadding;
+            int contentWidth = PanelWidth - (LeftPadding + RightPadding);
+
+            // Draw panel group so the minimize button is part of the UI
+            GUI.BeginGroup(new Rect(PanelX, PanelY, PanelWidth, panelHeight));
+            GUI.Box(new Rect(0, 0, PanelWidth, panelHeight), "Archipelago");
+
+            // Minimize button on the panel (top-right corner)
+            if (GUI.Button(new Rect(PanelWidth - PanelPadding - 24, PanelPadding, 24, 20), "—")) {
+                SetMinimized(true);
+                GUI.EndGroup();
+                return;
+            }
+
+            // Status
             if (ArchipelagoClient.session != null) {
                 if (ArchipelagoClient.isAuthenticated) {
-                    GUI.Label(new Rect(16, 16, 300, 20), "Status: Connected");
+                    GUI.Label(new Rect(LeftPadding, 16, contentWidth, LineHeight), "Status: Connected");
                 }
                 else {
-                    GUI.Label(new Rect(16, 16, 300, 20), "Status: Authentication failed");
+                    GUI.Label(new Rect(LeftPadding, 16, contentWidth, LineHeight), "Status: Authentication failed");
                 }
             }
             else {
-                GUI.Label(new Rect(16, 16, 300, 20), "Status: Not Connected");
+                GUI.Label(new Rect(LeftPadding, 16, contentWidth, LineHeight), "Status: Not Connected");
             }
 
             if ((ArchipelagoClient.session == null || !ArchipelagoClient.isAuthenticated) && ArchipelagoClient.state == APState.Menu ) {
-                GUI.Label(new Rect(16, 36, 150, 20), "Host: ");
-                GUI.Label(new Rect(16, 56, 150, 20), "Slot Name: ");
-                GUI.Label(new Rect(16, 76, 150, 20), "Password: ");
+                // Labels
+                GUI.Label(new Rect(labelX, 36, LabelWidth, LineHeight), "Host:");
+                GUI.Label(new Rect(labelX, 56, LabelWidth, LineHeight), "Slot Name:");
+                GUI.Label(new Rect(labelX, 76, LabelWidth, LineHeight), "Password:");
 
                 bool submit = Event.current.type == EventType.KeyDown && Event.current.keyCode == KeyCode.Return;
                 ArchipelagoInfo info = ArchipelagoClient.apInfo;
 
-                info.address = GUI.TextField(new Rect(150 + 16 + 8, 36, 150, 20), info.address);
-                info.slot = GUI.TextField(new Rect(150 + 16 + 8, 56, 150, 20), info.slot);
-                info.password = GUI.TextField(new Rect(150 + 16 + 8, 76, 150, 20), info.password);
+                // Inputs sized to fit within the panel
+                info.address = GUI.TextField(new Rect(fieldX, 36, fieldWidth, LineHeight), info.address);
+                info.slot = GUI.TextField(new Rect(fieldX, 56, fieldWidth, LineHeight), info.slot);
+                info.password = GUI.TextField(new Rect(fieldX, 76, fieldWidth, LineHeight), info.password);
 
                 if (submit && Event.current.type == EventType.KeyDown) {
                     // The text fields have not consumed the event, which means they were not focused.
                     submit = false;
                 }
 
-                if ((GUI.Button(new Rect(16, 96, 100, 20), "Connect") || submit) && info.Valid) {
+                if ((GUI.Button(new Rect(LeftPadding, 96, 100, LineHeight), "Connect") || submit) && info.Valid) {
                     ArchipelagoClient.Connect();
                     if(ArchipelagoClient.isAuthenticated) {
                         ItemHandler.Setup();
@@ -46,13 +109,15 @@ namespace RiftArchipelago{
                 }
             }
             else if(ArchipelagoClient.state == APState.Menu && ArchipelagoClient.session != null) {
-                GUI.Label(new Rect(16, 36, 150, 20), "Goal Song: " + ArchipelagoClient.slotData.goalSong);
+                GUI.Label(new Rect(LeftPadding, 36, contentWidth, LineHeight), "Goal Song: " + ArchipelagoClient.slotData.goalSong);
                 // GUI.Toggle(new Rect(16, 56, 100, 20), ArchipelagoClient.slotData.deathLink, "Death Link Toggle");
 
-                if(GUI.Button(new Rect(16, 76, 100, 20), "Disconnect")) {
+                if(GUI.Button(new Rect(LeftPadding, 76, 100, LineHeight), "Disconnect")) {
                     ArchipelagoClient.Disconnect();
                 }
             }
+
+            GUI.EndGroup();
         }
     }
 }

--- a/Patches/MainMenuPatches.cs
+++ b/Patches/MainMenuPatches.cs
@@ -1,6 +1,7 @@
 using UnityEngine;
 using HarmonyLib;
 using Shared.Title;
+using Shared.MenuOptions;
 
 namespace RiftArchipelago.Patches{
     [HarmonyPatch(typeof(MainMenuManager), "Awake")]
@@ -16,6 +17,34 @@ namespace RiftArchipelago.Patches{
             var guiGameObject = new GameObject("AP");
             ArchipelagoClient.apUI = guiGameObject.AddComponent<ArchipelagoUI>();
             Object.DontDestroyOnLoad(guiGameObject);
+        }
+    }
+
+    [HarmonyPatch(typeof(MainMenuManager), "Update")]
+    public static class APUIUpdatePatch {
+        private static readonly AccessTools.FieldRef<MainMenuManager, OptionsScreenInputController> _stageInputRecordRef =
+            AccessTools.FieldRefAccess<MainMenuManager, OptionsScreenInputController>("_inputController");
+        private static OptionsScreenInputController _inputController = null;
+
+        [HarmonyPrefix]
+        public static void PreFix(MainMenuManager __instance) {
+            // stageInputRecord: preferred via FieldRef, fallback to Traverse
+            try { _inputController = _stageInputRecordRef(__instance); } catch { }
+            if (_inputController == null)
+            {
+                try { _inputController = Traverse.Create(__instance).Field("_inputController").GetValue<OptionsScreenInputController>(); } catch { }
+            }
+            if (_inputController == null)
+            {
+                RiftAP._log.LogWarning("RRStageEnd PostFix: _inputController == null");
+                return;
+            }
+
+            if (ArchipelagoUI.AnyTextFieldFocused) {
+                _inputController.IsInputDisabled = true;
+            } else {
+                _inputController.IsInputDisabled = false;
+            }
         }
     }
 }

--- a/SlotData.cs
+++ b/SlotData.cs
@@ -37,5 +37,9 @@ namespace RiftArchipelago {
         private int ParseInt(object i) {
             return int.TryParse(i.ToString(), out var result) ? result : -1;
         }
+
+        public void SetDeathLink(bool value) {
+            deathLink = value;
+        }
     }
 }

--- a/SlotData.cs
+++ b/SlotData.cs
@@ -47,6 +47,7 @@ namespace RiftArchipelago {
 
         public void SetDeathLink(bool value) {
             deathLink = value;
+        }
           
         public static Grade MapObjectToGrade(object g) {
             if (g == null) return Grade.Any;


### PR DESCRIPTION
- Added logic for the basic AP client UI to be minimized. This stops it from covering song titles
- Added a button for death link toggling for later use
- Player prefs now stores the most recent connection details and loads them on launch
- Menu navigation is now disabled when focused on a text field